### PR TITLE
Don't try to check the localized "held messages" page title

### DIFF
--- a/listadmin3
+++ b/listadmin3
@@ -100,9 +100,6 @@ class Mailman3UI:
             print(f"Held messages :{page.text}:")
 
         msg_form = page.soup.find("h2")
-        if msg_form.text.strip() != "Held Messages":
-            raise HTMLParseError("Couldn't find held message list")
-
         return msg_form
 
     def get_held_messages(self, listname: str) -> list[dict]:


### PR DESCRIPTION
This heading text is localized in the Mailman3 web UI, so we can't reliably check it and have to relay on the "h2" element being the correct one ...

Closes #1.