### PR TITLE
Subscriptions: Don't try to validate the localized page title

### DIFF
--- a/listadmin3
+++ b/listadmin3
@@ -165,8 +165,6 @@ class Mailman3UI:
             print(page.text)
 
         sub_table = page.soup.find("h2")
-        if "Subscriptions pending approval" not in sub_table.text:
-            raise HTMLParseError("Couldn't find pending subscriber list")
         sub_table = sub_table.find_next_sibling("div")
         sub_table = sub_table.find("table")
         sub_list = sub_table.find("tbody")


### PR DESCRIPTION
This heading text is localized in the Mailman3 web UI, so we can't reliably check it and have to relay on the `<h2>` element being the correct one ...

Basically the same was fixed in commit 57c30fc78136 for held messages.

Closes #4.