### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+SHELL = /bin/sh
+# a BSD or GNU style install is required, e.g., /usr/ucb/install on Solaris
+INSTALL = install
+
+PREFIX = /usr/local
+prefix = $(PREFIX)
+bindir = $(prefix)/bin
+mandir = $(prefix)/share/man
+
+all:
+	@echo Nothing needs to be done
+
+install:
+	$(INSTALL) -d $(DESTDIR)$(bindir) $(DESTDIR)$(mandir)/man1
+	$(INSTALL) -m 755 listadmin3 $(DESTDIR)$(bindir)/listadmin3
+	$(INSTALL) -m 644 listadmin3.1 $(DESTDIR)$(mandir)/man1/listadmin3.1


### PR DESCRIPTION
Not everyone uses Debian or a Debian based system, so I have created a Makefile that can be used to install listadmin3 in the correct places. This makes it available system wide for all users.

By default it installs in the /usr/local tree, which will be automatically overridden with the /usr tree in RPM packaging due to the «$(DESTDIR)» variable.