### PR TITLE
Add inline script metadata to listadmin3

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ currently probably only works on *nix style machines, due to how it handles
 accepting a single character response without the need for enter (in the `getch`
 function).
 
+You can run listadmin3 without installation using (for example) the
+[uv](https://docs.astral.sh/uv/) Python package and project manager like this:
+
+```shell
+uv run --script /path/to/listadmin3
+```
+
 ### Downloads
 
 listadmin3 is available via [GitHub](https://github.com/) at

--- a/listadmin3
+++ b/listadmin3
@@ -1,5 +1,12 @@
 #!/usr/bin/python3
 #
+# /// script
+# requires-python = ">=3"
+# dependencies = [
+#   "mechanicalsoup",
+# ]
+# ///
+#
 # Copyright 2023 Jonathan McDowell <noodles@earth.li>
 #
 # This program is free software: you can redistribute it and/or modify it under


### PR DESCRIPTION
Documentation:
<https://packaging.python.org/en/latest/specifications/inline-script-metadata/#inline-script-metadata>

This allows tools to automatically set up an environment for running
listadmin3 which, for example, "uv run" can make use of. An example is
added to the README.md file.
